### PR TITLE
chore: upgrade Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mholt/caddy-l4
 
-go 1.25
+go 1.26.0
 
 require (
 	github.com/caddyserver/caddy/v2 v2.6.2


### PR DESCRIPTION
## Summary
- Upgraded Go version from 1.25 to 1.26.0

Supersedes #14 (which had merge conflicts due to diverged dependencies).

## Test plan
- [ ] Review changes and verify build passes
